### PR TITLE
Add the parameter to selcect the SSL version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,5 +40,5 @@ setup(
     ],
     keywords=['SharePoint'],
     packages=['shareplum'],
-    install_requires=['lxml', 'requests', 'requests-ntlm'],
+    install_requires=['lxml', 'requests', 'requests-ntlm', 'requests-toolbelt'],
 )

--- a/shareplum/shareplum.py
+++ b/shareplum/shareplum.py
@@ -5,15 +5,20 @@ import requests
 from datetime import datetime
 import re
 
+from requests_toolbelt import SSLAdapter
+
 class Site(object):
     """Connect to SharePoint Site
     """
 
-    def __init__(self, site_url, auth=None, verify_ssl=True):
+    def __init__(self, site_url, auth=None, verify_ssl=True, ssl_version=None):
         self.site_url = site_url
         self._verify_ssl = verify_ssl
         
         self._session = requests.Session()
+        if ssl_version is not None:
+            self._session.mount('https://', SSLAdapter(ssl_version))
+
         self._session.headers.update({'user-agent':
                                       'shareplum/%s' % __version__ })
 


### PR DESCRIPTION
In some Linux distributions that using OpenSSL 1.0.1f or older, TLS1.2 protocol doesn't work.
( cf. https://rt.openssl.org/Ticket/Display.html?user=guest&pass=guest&id=2771 )

I added the parameter 'tls_version' to select the version of SSL/TLS protocol.

example:
```
site = Site(SITE, auth=auth, verify_ssl=False, ssl_version='TLSv1')
```