### PR TITLE
Add Flag to List constructor to exclude hidden fields

### DIFF
--- a/docs/objects.rst
+++ b/docs/objects.rst
@@ -45,9 +45,11 @@ Methods
 
     Returns information on the userbase of the current Site.
 
-.. py:function:: List(listName)
+.. py:function:: List(listName, exclude_hidden_fields=False)
 
     Returns a List object for the list with 'listName' on the current Site.
+
+    Sometimes internal fields can take the same DisplayName as visible fields, effectively hiding them from SharePlum. When 'exclude_hidden_fields' is True, these internal fields won't be loaded.
 
 List
 ====


### PR DESCRIPTION
Sometimes there are multiple fields with the same DisplayName. Common conflicts in our german Sharepoint 2013 server are `Name` and `Pfad`. By excluding hidden fields from `List `I'm able to remove fields that are not interesting to my Python scripts and stop them from hiding the fields I want to query.