### PR TITLE
added download_file function to work with non-text files

### DIFF
--- a/shareplum/folder.py
+++ b/shareplum/folder.py
@@ -111,3 +111,14 @@ class _Folder():
     def get_file(self, file_name):
         response = self._session.get(self.site_url + f"/_api/web/GetFileByServerRelativeUrl('{self.info['d']['ServerRelativeUrl']}/{file_name}')/$value")
         return response.text
+
+    
+    def download_file(self, source_file_name, dest_file_name):
+        """
+            downloads source_file_name from the sharepiont folder and saves it to dest_file_name
+        """
+        response = self._session.get(self.site_url + f"/_api/web/GetFileByServerRelativeUrl('{self.info['d']['ServerRelativeUrl']}/{source_file_name}')/$value")
+        if response.status_code == 200:
+            with open (dest_file_name, 'wb') as f:
+                f.write(response.content)
+


### PR DESCRIPTION
get_file returns response.text which unfortunately does not work for other file types. For example, downloading a jpg file will not work using response.text. response.content is necessary for non-text files.

This seems to be a common enough use case. I found [this stack overflow post](**url**) before solving it myself.

The tests don't pass for me so I didn't add any of my own but I have tested this with multiple file types and it does work. I can add some if you create a contributing guide that explains how to set them up.