### PR TITLE
restore folder.get_file

### DIFF
--- a/shareplum/folder.py
+++ b/shareplum/folder.py
@@ -149,22 +149,7 @@ class _Folder():
 
         return None
 
-    def read_txt_file(self, file_name):
+    def get_file(self, file_name):
         response = self._session.get(self.site_url + f"/_api/web/GetFileByServerRelativeUrl('{self.info['d']['ServerRelativeUrl']}/{file_name}')/$value")
-        if response.status_code != 200:
-            response.raise_for_status()
-            raise RuntimeError("Response code: " + str(response.status_code) + ", response: " + str(response.text))
-        return response.text
-
-
-    def download_file(self, source_file_name, dest_file_name):
-        """
-            downloads source_file_name from the sharepiont folder and saves it to dest_file_name
-        """
-        response = self._session.get(self.site_url + f"/_api/web/GetFileByServerRelativeUrl('{self.info['d']['ServerRelativeUrl']}/{source_file_name}')/$value")
-        if response.status_code == 200:
-            with open (dest_file_name, 'wb') as f:
-                f.write(response.content)
-        else:
-            response.raise_for_status()
-            raise RuntimeError("Response code: " + str(response.status_code) + ", response: " + str(response.text))
+        response.raise_for_status()
+        return response.content


### PR DESCRIPTION
resolves #82 

Sadly anyone who has pulled tip and is using get_text_file or download_file will find they're gone now.  We could re-write those as wrapper functions that use get_file, but I've opted to remove them as they've not gone into a release.