### PR TITLE
pass through timeout to folder from site

### DIFF
--- a/shareplum/folder.py
+++ b/shareplum/folder.py
@@ -3,11 +3,11 @@ import json
 
 
 class _Folder():
-    def __init__(self, session, folder_name, url):
+    def __init__(self, session, folder_name, url, timeout=None):
         self._session = session
         self.folder_name = folder_name
         self.site_url = url
-        self.timeout = 3
+        self.timeout = timeout
 
         self.info = self._create_folder()
 

--- a/shareplum/site.py
+++ b/shareplum/site.py
@@ -415,7 +415,7 @@ class _Site365(_Site2007):
     def Folder(self, folder_name):
         """Sharepoint Folder Web Service
         """
-        return _Folder(self._session, folder_name, self.site_url)
+        return _Folder(self._session, folder_name, self.site_url, timeout=self.timeout)
 
     def _get_form_digest_value(self):
         response = post(self._session, self.site_url + "/_api/contextinfo")


### PR DESCRIPTION
I think I've found the cause of the intermittent timeouts I've hit.  I was seeing 3 seconds read timeout, traced it to the folder class.  The site class can be given a connection/read timeout and defaults to None.  Folder just sets this value to 3, it should be inherited from site and also default to None.

If you accept this, please make a release after so I can pull it in.

Thanks