### PR TITLE
Fixing Update list items  with SP user on SharePoint 2007

### DIFF
--- a/shareplum/list.py
+++ b/shareplum/list.py
@@ -175,7 +175,7 @@ class _List2007:
                 else:
                     raise Exception("%s not a valid Boolean Value, only 'Yes' or 'No'" % value)
             elif self.users and field_type == "User":
-                return self.users["py"][value]
+                return self.users["py"][key]
             else:
                 return value
         except AttributeError:


### PR DESCRIPTION
There is a bug where on SharePoint 2007, trying to update list with user information fails as it is looking for value instead of key. Changing to key lookup fixed the issue and update list item function works and updates the data.